### PR TITLE
Added writeVCF function

### DIFF
--- a/GBS-Chip-Gmatrix.R
+++ b/GBS-Chip-Gmatrix.R
@@ -1064,8 +1064,8 @@ writeVCF <- function(indsubset=NULL, snpsubset=NULL, outname=NULL, ep=0){
     out[,2] <- 1:length(snpsubset)
   }
   out[,3] <- rep(".", length(snpsubset))
-  out[,4] <- rep("R", length(snpsubset))
-  out[,5] <- rep("A", length(snpsubset))
+  out[,4] <- rep("C", length(snpsubset))
+  out[,5] <- rep("G", length(snpsubset))
   out[,6] <- rep(".", length(snpsubset))
   out[,7] <- rep(".", length(snpsubset))
   out[,8] <- rep(".", length(snpsubset))

--- a/GBS-Chip-Gmatrix.R
+++ b/GBS-Chip-Gmatrix.R
@@ -1024,3 +1024,78 @@ GCompare <- function(Glist,IDlist,Gnames = paste0("G.",1:length(Glist)), plotnam
 # disequilibrium cut-off at -0.05
 
 
+## Write KGD back to VCF file
+writeVCF <- function(indsubset=NULL, snpsubset=NULL, outname=NULL, ep=0){
+  
+  filename <- paste0(outname,".vcf")
+  if(!exists("alleles"))
+    stop("Allele matrix does not exist. Change the 'alleles.keep' argument to TRUE and rerun KGD")  
+  else{
+    ref <- alleles[, seq(1, 2 * nsnps - 1, 2)]
+    alt <- alleles[, seq(2, 2 * nsnps, 2)]
+  }
+  ## subset data if required
+  if(missing(indsubset))
+    indsubset <- 1:nind
+  if(missing(snpsubset))
+    snpsubset <- 1:nsnps
+  ref <- ref[indsubset, snpsubset]
+  alt <- alt[indsubset, snpsubset]
+  genon0 <- genon[indsubset, snpsubset]
+  
+  # Meta information
+  metaInfo <- paste('##fileformat=VCFv4.3',paste0("##fileDate=",Sys.Date()),"##source=KGDpackage",
+                    '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
+                    '##FORMAT=<ID=GP,Number=G,Type=Float,Description="Genotype Probability">',
+                    '##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allele Read Counts">\n',sep="\n")
+  cat(metaInfo, file=filename)
+  ## colnames:
+  cat(c("#CHROM", "POS", "ID", "REF","ALT","QUAL","FILTER","INFO","FORMAT", seqID[indsubset], "\n"), file=filename, append=T, sep="\t")
+  ## set up the matrix to be written
+  out <- matrix(nrow=length(snpsubset),ncol=9+length(indsubset))
+  
+  ## Compute the Data line fields
+  if(gform == "tassel"){
+    out[,1] <- chrom[snpsubset]
+    out[,2] <- pos[snpsubset]
+  }
+  else{
+    out[,1] <- SNP_Names[snpsubset]
+    out[,2] <- 1:length(snpsubset)
+  }
+  out[,3] <- rep(".", length(snpsubset))
+  out[,4] <- rep("R", length(snpsubset))
+  out[,5] <- rep("A", length(snpsubset))
+  out[,6] <- rep(".", length(snpsubset))
+  out[,7] <- rep(".", length(snpsubset))
+  out[,8] <- rep(".", length(snpsubset))
+  out[,9] <- rep("GT:GP:AD", length(snpsubset))
+  
+  ## Compute the genotype fields
+  genon0[is.na(genon0)] <- -1
+  gt <- sapply(as.vector(genon0), function(x) switch(x+2,"./.","1/1","0/1","0/0"))
+  ## compute probs
+  compProb <- function(x) 1/2^(ref+alt)*((2-x)*ep + x*(1-ep))^ref * ((2-x)*(1-ep) + x*ep)^alt
+  paa <- compProb(2)
+  pab <- compProb(1)
+  pbb <- compProb(0)
+  psum <- paa + pab + pbb
+  paa <- round(paa/psum,4)
+  pab <- round(pab/psum,4)
+  pbb <- round(pbb/psum,4)
+  ## Create the data part
+  temp <- options()$scipen
+  options(scipen=10)  #needed for formating
+  out[,-c(1:9)] <- matrix(paste(gt,paste(paa,pab,pbb,sep=","),paste(ref,alt,sep=","), sep=":"), 
+                          nrow=length(snpsubset), ncol=length(indsubset), byrow=T)
+  options(scipen=temp)
+  
+  ## fwrite is much faster
+  if(require(data.table))
+    fwrite(split(t(out), 1:(length(indsubset)+9)), file=filename, sep="\t", append=T, nThread = 1)
+  else
+    write.table(out, file = filename, append = T, sep="\t", col.names = F, row.names=F)
+  return(invisible(NULL))
+}
+
+


### PR DESCRIPTION
writeVCF function writes KGD data to VCF format.

Arguments are:
- indsubset for specifying a subset of individuals
- snpsubset for specifying a subset of snps
- outname for specifying the name of the output file
- ep is the probability of a sequencing error. Default to zero.

Notes:
- Used the method of Li (2011) to compute genotype likelihoods.
- Genotype probabilities are computed using Bayes theorem with HWE allele frequency estimates for genotype probabilities and P(read|Genotype) is as in GUSMap and GUS-LD.
