### PR TITLE
pathToCppFile: fix for nested source().

### DIFF
--- a/GBS-Chip-Gmatrix.R
+++ b/GBS-Chip-Gmatrix.R
@@ -18,7 +18,12 @@ pathToCppFile = function() {
     cpp.name <- "GBS-Rcpp-functions.cpp"
     this.file <- NULL
     for (i in -(1:sys.nframe())) {
-        if (identical(sys.function(i), base::source)) this.file <- (normalizePath(sys.frame(i)$ofile))
+        if (identical(sys.function(i), base::source)) {
+            f <- sys.frame(i)
+            if (!f$chdir)
+                this.file <- normalizePath(f$ofile)
+            break
+        }
     }
     if (!is.null(this.file)) {
         source.dir <- dirname(this.file)


### PR DESCRIPTION
This fixes errors that occur when GBS-Chip-Gmatrix.R is sourced from a
script in a different directory which is in turn sourced by another
script.

If multiple source calls are nested, then we should only look at the
path parameter for the inner-most source() frame. If the inner-most
frame had that chdir option set, then we don't need to translate the
filename.