### PR TITLE
Nix: bump to nixpkgs-unstable and expose required R packages

### DIFF
--- a/GBS-Chip-Gmatrix.R
+++ b/GBS-Chip-Gmatrix.R
@@ -1,6 +1,6 @@
 #!/bin/echo Source me don't execute me 
 
-KGDver <- "1.3.1"
+KGDver <- "1.3.2"
 cat("KGD version:",KGDver,"\n")
 if (!exists("nogenos"))          nogenos          <- FALSE
 if (!exists("gform"))            gform            <- "uneak"

--- a/GBS-PopGen.R
+++ b/GBS-PopGen.R
@@ -1,4 +1,4 @@
-PopGenver <- "1.3.1"
+PopGenver <- "1.3.2"
 cat("GBS-PopGen for KGD version:",PopGenver,"\n")
 
 heterozygosity <- function(indsubsetgf=1:nind,snpsubsetgf=1:nsnps,maxiter=100,convtol=0.001){

--- a/GBSPedAssign.R
+++ b/GBSPedAssign.R
@@ -1,5 +1,5 @@
 #!/bin/echo Source me don't execute me 
-pedver <- "1.3.0"
+pedver <- "1.3.2"
 cat("GBS-PedAssign for KGD version:",pedver,"\n")
 
   verif.ch <- c(".","Y","N")  # NA, Y, N

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731797254,
-        "narHash": "sha256-df3dJApLPhd11AlueuoN0Q4fHo/hagP75LlM5K1sz9g=",
+        "lastModified": 1753151930,
+        "narHash": "sha256-XSQy6wRKHhRe//iVY5lS/ZpI/Jn6crWI8fQzl647wCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
+        "rev": "83e677f31c84212343f4cc553bab85c2efcad60a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Naive Nix packaging for KGD";
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     flake-utils.url = "github:numtide/flake-utils";
   };
@@ -19,62 +19,23 @@
             inherit system;
           };
 
-          # we need a recent Rcpp with this fix:
-          # https://github.com/RcppCore/Rcpp/pull/1346
-          recent-Rcpp = pkgs.rPackages.buildRPackage {
-            name = "Rcpp";
-
-            version = "1.0.13.6";
-
-            src = pkgs.fetchFromGitHub {
-              owner = "RcppCore";
-              repo = "Rcpp";
-              rev = "83e640b55aeaeba8a746d0da6152cabe8af41154";
-              hash = "sha256-x0s9BRIAxxZmNFXRYwtpmT5asD4+mhIUTqwYsaPOgi4=";
-            };
-          };
-
-          # TODO: it should be possible to simply override the Rcpp dependency for RcppArmadillo in nixpkgs,
-          # but I didn't work out how to do that
-          RcppArmadillo-with-recent-Rcpp = pkgs.rPackages.buildRPackage {
-            name = "RcppArmadillo";
-
-            version = "0.12.8.1.0";
-
-            src = pkgs.fetchFromGitHub {
-              owner = "RcppCore";
-              repo = "RcppArmadillo";
-              rev = "8abe7be9fc4dd7c1d2b02ed200707232d6fd1f09"; # 0.12.8.1.0
-              hash = "sha256-+Li4ln/4ZyBY+I8S8X4uSmFaG1D3q5UJOJJB5pLRubo=";
-            };
-
-            propagatedBuildInputs = [ recent-Rcpp ];
-          };
-
-
-          KDG-R = pkgs.rWrapper.override
-            {
-              packages = with pkgs.rPackages; [
-                RcppArmadillo-with-recent-Rcpp
-                data_table
-                R_utils
-                plotly
-                heatmaply
-                parallelDist
-                MethComp
-                MASS
-              ];
-            };
+          KGD-rPackages = with pkgs.rPackages;
+            [
+              RcppArmadillo
+              data_table
+              R_utils
+              plotly
+              heatmaply
+              parallelDist
+              MethComp
+              MASS
+            ];
 
           KDG-src = pkgs.stdenv.mkDerivation {
             pname = "KDG-src";
-            version = "1.2.2";
+            version = "1.3.1";
 
             src = ./.;
-
-            buildInputs = [ KDG-R ];
-
-            propagatedBuildInputs = [ KDG-R ];
 
             nativeBuildInputs = [ pkgs.dos2unix ];
 
@@ -95,6 +56,7 @@
         {
           packages = {
             src = KDG-src;
+            rPackages = KGD-rPackages;
           };
         });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,7 @@
 
           KDG-src = pkgs.stdenv.mkDerivation {
             pname = "KDG-src";
-            version = "1.3.1";
+            version = "1.3.2";
 
             src = ./.;
 


### PR DESCRIPTION
The previous constraint from gbs-prism to use an older version of nixpkgs has been removed, and the advantage of using nixpkgs-unstable is that it has the fixed Rcpp that we need.

Exposing the R packages directly seems now to be required in order to use KGD both in gbs-prism and downstream of that in gbs-uber-keyfiles.