### PR TITLE
Changed writeVCF to give correct output in vcf file

### DIFF
--- a/GBS-Chip-Gmatrix.R
+++ b/GBS-Chip-Gmatrix.R
@@ -2567,8 +2567,10 @@ writeVCF <- function(indsubset, snpsubset, outname=NULL, ep=0.001, puse = p, IDu
   filename <- paste0(outname,".vcf")
   if(gform=="chip" & max(depth) == Inf & !exists("alleles")) {  # create alleles for chip data
    ref <- alt <- matrix(0,nrow=nind, ncol=nsnps)
-   ref[genon >= 1] <- Inf
-   alt[genon <= 1] <- Inf
+   ref[genon > 1] <- 10000
+   ref[genon == 1] <- 1e-8
+   alt[genon < 1] <- 10000
+   alt[genon == 1] <- 1e-8
    }
   else if(!exists("alleles"))
     stop("Allele matrix does not exist. Change the 'alleles.keep' argument to TRUE and rerun KGD")


### PR DESCRIPTION
Found issue creating VCF from chip data. Was getting NaN values in the VCF file for GL and GP fields and some incorrect GTs. The changes are more of a hack to make it work in the given code.

Possibly should set the argument ep=0 for chip as will.